### PR TITLE
Fix links to ORCID iD

### DIFF
--- a/_extensions/ctk-article/typst-template.typ
+++ b/_extensions/ctk-article/typst-template.typ
@@ -211,7 +211,7 @@
         ..slice.map(author => align(center, {
               text(weight: "bold", author.name)
               if "orcid" in author [
-                #link("https://https://orcid.org/" + author.orcid)[
+                #link("https://orcid.org/" + author.orcid)[
                   #box(height: 9pt, image("ORCIDiD.svg"))
                 ]
               ]


### PR DESCRIPTION
The ORCID iD icons were linking to `https://https://orcid.org/0000-0000-0000-0000`