### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/ctk-article/_schema.yml
+++ b/_extensions/ctk-article/_schema.yml
@@ -1,0 +1,56 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+formats:
+  ctk-article-typst:
+    title-page:
+      type: boolean
+      default: false
+      description: Render a standalone title page.
+    blind:
+      type: boolean
+      default: false
+      description: Hide author details for blinded review.
+    mainfont:
+      type: array
+      items:
+        type: string
+      description: Preferred font fallback list for body text.
+    codefont:
+      type: string
+      description: Monospace font for code blocks.
+    date-format:
+      type: string
+      description: Date formatting style.
+    linestretch:
+      type: number
+      description: Line spacing multiplier.
+    linkcolor:
+      type: string
+      description: Link colour used in the PDF.
+      completion:
+        type: color
+    bibliographystyle:
+      type: string
+      description: Citation style used by Typst.
+    biblio-title:
+      type: string
+      description: Heading for the bibliography section.
+    section-numbering:
+      type: string
+      description: Section numbering style.
+
+attributes:
+  _any:
+    arguments:
+      type: string
+      description: Arguments passed to a Typst function wrapper class.
+    spread:
+      type: boolean
+      description: Spread function arguments over nested calls.
+    label:
+      type: string
+      description: Label inserted after the generated Typst block.
+
+classes:
+  appendix:
+    description: Marks the first appendix section to switch Typst appendix rendering.

--- a/_extensions/ctk-article/_snippets.json
+++ b/_extensions/ctk-article/_snippets.json
@@ -1,6 +1,6 @@
 {
   "ctk-article format": {
-    "prefix": "ctk-article-format",
+    "prefix": "format",
     "body": [
       "format:",
       "  ctk-article-typst:",
@@ -11,7 +11,7 @@
     "description": "Configure the ctk-article Typst format."
   },
   "Appendix heading": {
-    "prefix": "ctk-appendix",
+    "prefix": "appendix",
     "body": [
       "## ${1:Appendix title} {.appendix}",
       "",
@@ -20,7 +20,7 @@
     "description": "Insert an appendix heading that triggers appendix mode."
   },
   "Typst function span": {
-    "prefix": "ctk-typst-function",
+    "prefix": "function",
     "body": [
       "[${1:content}]{.${2:text} arguments=\"${3:fill:blue}\"}"
     ],

--- a/_extensions/ctk-article/_snippets.json
+++ b/_extensions/ctk-article/_snippets.json
@@ -1,0 +1,29 @@
+{
+  "ctk-article format": {
+    "prefix": "ctk-article-format",
+    "body": [
+      "format:",
+      "  ctk-article-typst:",
+      "    title-page: ${1:false}",
+      "    blind: ${2:false}",
+      "    linestretch: ${3:1.25}"
+    ],
+    "description": "Configure the ctk-article Typst format."
+  },
+  "Appendix heading": {
+    "prefix": "ctk-appendix",
+    "body": [
+      "## ${1:Appendix title} {.appendix}",
+      "",
+      "$0"
+    ],
+    "description": "Insert an appendix heading that triggers appendix mode."
+  },
+  "Typst function span": {
+    "prefix": "ctk-typst-function",
+    "body": [
+      "[${1:content}]{.${2:text} arguments=\"${3:fill:blue}\"}"
+    ],
+    "description": "Wrap inline content with a typst-function class and arguments."
+  }
+}


### PR DESCRIPTION
This PR improves Quarto Wizard support (VS Code/Positron) for this extension by adding extension metadata files used for editor assistance.

### What this adds
- `_schema.yml` with extension-specific fields (options/classes/attributes and/or format keys) to enable better completion, hover docs, and validation.
- `_snippets.json` with practical insertion snippets for common extension usage.

### Why
These files improve authoring UX in Quarto projects by making extension configuration and usage easier to discover and less error-prone in VSCode/Positron when using Quarto Wizard.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html